### PR TITLE
Generate AppImage for each git push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - # source /opt/qt*/bin/qt*-env.sh
 
 script:
-  - ./configure --prefix=/usr
+  - bash ./configure --prefix=/usr
   - make -j$(nproc)
   - make install DESTDIR=$(readlink -f appdir) ; find appdir/
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt59-trusty -y
+    - sudo apt-get update -qq
+
+install:
+    - sudo apt-get -y install qt59base
+    - source /opt/qt*/bin/qt*-env.sh
+
+script:
+  - ./configure --prefix=/usr
+  - make -j$(nproc)
+  - make install DESTDIR=$(readlink -f appdir) ; find appdir/
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+
+after_success:
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ sudo: require
 dist: trusty
 
 before_install:
-    - sudo add-apt-repository ppa:beineri/opt-qt59-trusty -y
-    - sudo apt-get update -qq
+    - # sudo add-apt-repository ppa:beineri/opt-qt59-trusty -y
+    - # sudo apt-get update -qq
 
 install:
-    - sudo apt-get -y install qt59base
-    - source /opt/qt*/bin/qt*-env.sh
+    - sudo apt-get -y install gcc make libx11-dev libxext-dev libxi-dev libfreetype6-dev libfontconfig1-dev zlib1g-dev libjpeg-dev libpng12-dev
+    - # source /opt/qt*/bin/qt*-env.sh
 
 script:
   - ./configure --prefix=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - # sudo apt-get update -qq
 
 install:
-    - sudo apt-get -y install aclocal gcc make libx11-dev libxext-dev libxi-dev libfreetype6-dev libfontconfig1-dev zlib1g-dev libjpeg-dev libpng12-dev
+    - sudo apt-get -y install automake gcc make libx11-dev libxext-dev libxi-dev libfreetype6-dev libfontconfig1-dev zlib1g-dev libjpeg-dev libpng12-dev
     - # source /opt/qt*/bin/qt*-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,8 @@ compiler: gcc
 sudo: require
 dist: trusty
 
-before_install:
-    - # sudo add-apt-repository ppa:beineri/opt-qt59-trusty -y
-    - # sudo apt-get update -qq
-
 install:
     - sudo apt-get -y install automake gcc make libx11-dev libxext-dev libxi-dev libfreetype6-dev libfontconfig1-dev zlib1g-dev libjpeg-dev libpng12-dev
-    - # source /opt/qt*/bin/qt*-env.sh
 
 script:
   - bash ./configure --prefix=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - # sudo apt-get update -qq
 
 install:
-    - sudo apt-get -y install gcc make libx11-dev libxext-dev libxi-dev libfreetype6-dev libfontconfig1-dev zlib1g-dev libjpeg-dev libpng12-dev
+    - sudo apt-get -y install aclocal gcc make libx11-dev libxext-dev libxi-dev libfreetype6-dev libfontconfig1-dev zlib1g-dev libjpeg-dev libpng12-dev
     - # source /opt/qt*/bin/qt*-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ script:
 
 after_success:
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - curl --upload-file ./APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - curl --upload-file ./AzPainter*.AppImage https://transfer.sh/AzPainter-git.$(git rev-parse --short HEAD)-x86_64.AppImage


### PR DESCRIPTION
Closes #3 when merged.

This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.