### PR TITLE
build: support out of tree builds

### DIFF
--- a/mlib/Makefile.am
+++ b/mlib/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS=-Iinclude -Isrc/private -I@freetype_dir@
+AM_CPPFLAGS="-I@top_srcdir@/mlib/include" "-I@top_srcdir@/mlib/src/private" -I@freetype_dir@
 AM_CFLAGS=-pthread
 
 noinst_LIBRARIES=libmlib.a

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS=-I../mlib/include -Iinclude -I@freetype_dir@ -DPACKAGE_DATA_DIR=\""$(datadir)/azpainter"\"
+AM_CPPFLAGS="-I@top_srcdir@/mlib/include" "-I@top_srcdir@/src/include" -I@freetype_dir@ -DPACKAGE_DATA_DIR=\""$(datadir)/azpainter"\"
 AM_CFLAGS=-pthread
 
 bin_PROGRAMS=azpainter


### PR DESCRIPTION
Don't assume make is run from the root, these changes enable:

```
$ autoreconf --install
$ mkdir build; cd build
$ ../configure
$ make
```