### PR TITLE
Fix typo in English translation.

### DIFF
--- a/translation/en
+++ b/translation/en
@@ -572,7 +572,7 @@
 +=Delete
 100=History
 +=Register
-+=Templet
++=Template
 1000=The maximum edit size is %d px
 
 #------------------


### PR DESCRIPTION
I found this wil starting the translation to Swedish due to being inspired by [this HN comment](https://news.ycombinator.com/item?id=29682878).